### PR TITLE
Fix path for ServiceMonitor to the one exposed by trickster

### DIFF
--- a/charts/trickster/Chart.yaml
+++ b/charts/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Trickster is an HTTP Reverse Proxy Cache and time series query accelerator.
 name: trickster
-version: 1.5.2
+version: 1.5.3
 home: https://github.com/tricksterproxy/trickster
 icon: https://helm.tricksterproxy.io/img/trickster-horizontal.png
 sources:

--- a/charts/trickster/templates/servicemonitor.yaml
+++ b/charts/trickster/templates/servicemonitor.yaml
@@ -22,6 +22,6 @@ spec:
       - {{ .Release.Namespace | quote }}
   endpoints:
   - port: http-metrics
-    path: {{ .Values.service.metricsPort }}
+    path: /metrics
     interval: {{ .Values.prometheus.serviceMonitor.interval }}
 {{- end }}


### PR DESCRIPTION
Currently deploying the ServiceMonitor fails with the following issue
```
ServiceMonitor.monitoring.coreos.com \"trickster-proxy\" is invalid: 
spec.endpoints.path: Invalid value: \"integer\": spec.endpoints.path in body must be of type string: \"integer\""
```

The setup of `path: {{ .Values.service.metricsPort }}` is incorrect. The path value is supposed to be the `HTTP path to scrape for metrics.` not the metrics port as is the current setup.
Trickster exposes metrics at the `/metrics` endpoint behind the 8481 port. This can be tested by querying the trickster service with `curl http://trickster-proxy.monitoring.svc.cluster.local:8481/metrics` which returns the available metrics.

The ServiceMonitor path should therefore be `/metrics`.
