### PR TITLE
Remove duplicate annotations

### DIFF
--- a/charts/trickster/Chart.yaml
+++ b/charts/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Trickster is an HTTP Reverse Proxy Cache and time series query accelerator.
 name: trickster
-version: 1.5.3
+version: 1.5.4
 home: https://github.com/tricksterproxy/trickster
 icon: https://helm.tricksterproxy.io/img/trickster-horizontal.png
 sources:

--- a/charts/trickster/templates/deployment.yaml
+++ b/charts/trickster/templates/deployment.yaml
@@ -26,8 +26,6 @@ spec:
     {{- end }}    
       labels:
         {{- include "trickster.labels" . | nindent 8 }}
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
 {{- if .Values.affinity }}
       affinity:


### PR DESCRIPTION
AFAIRememer the configmap checksum is to make the chart updates/triggers when the only deployed changed is an updated config map.

The set I left in here is the most inclusive - it has the checksum as well as the passthrough annotations from the values file. I don't think the name of the checksum actually matters.