### PR TITLE
Refactoring labels

### DIFF
--- a/charts/trickster/templates/_helpers.tpl
+++ b/charts/trickster/templates/_helpers.tpl
@@ -31,25 +31,25 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Generate basic labels */}}
+{{- define "trickster.labels" }}
+app.kubernetes.io/component: trickster-infra
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "trickster.name" . }}
+app.kubernetes.io/part-of: {{ template "trickster.name" . }} 
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
+tricksterproxy.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- end }}
+
 {{/*
-Create unified labels for trickster
+Specify default selectors
 */}}
-{{- define "trickster.common.matchLabels" -}}
-app: {{ template "trickster.name" . }}
-release: {{ .Release.Name }}
-{{- end -}}
-
-{{- define "trickster.common.metaLabels" -}}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-heritage: {{ .Release.Service }}
-{{- end -}}
-
-{{- define "trickster.labels" -}}
-{{ include "trickster.matchLabels" . }}
-{{ include "trickster.common.metaLabels" . }}
-{{- end -}}
-
-{{- define "trickster.matchLabels" -}}
-component: {{ template "trickster.name" . }}
-{{ include "trickster.common.matchLabels" . }}
-{{- end -}}
+{{- define "trickster.selectors" }}
+app.kubernetes.io/name: {{ template "trickster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/trickster/templates/_helpers.tpl
+++ b/charts/trickster/templates/_helpers.tpl
@@ -40,7 +40,7 @@ app.kubernetes.io/name: {{ template "trickster.name" . }}
 app.kubernetes.io/part-of: {{ template "trickster.name" . }} 
 app.kubernetes.io/version: "{{ .Chart.Version }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
-tricksterproxy.io/version: {{ .Chart.AppVersion }}
+tricksterproxy.io/version: "{{ .Chart.AppVersion }}"
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/trickster/templates/configmap.yaml
+++ b/charts/trickster/templates/configmap.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
   name: {{ template "trickster.fullname" . }}
 data:
   trickster.conf: |-

--- a/charts/trickster/templates/deployment.yaml
+++ b/charts/trickster/templates/deployment.yaml
@@ -6,12 +6,14 @@ metadata:
 {{ toYaml .Values.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
   name: {{ template "trickster.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "trickster.matchLabels" . | nindent 6 }}
+      app: {{ template "trickster.name" . }}
+      {{- include "trickster.selectors" . | indent 6 }}
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.strategy }}
   strategy:
@@ -25,7 +27,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}    
       labels:
-        {{- include "trickster.labels" . | nindent 8 }}
+        app: {{ template "trickster.name" . }}
+        {{- include "trickster.labels" . | indent 8 }}
     spec:
 {{- if .Values.affinity }}
       affinity:

--- a/charts/trickster/templates/ingress.yaml
+++ b/charts/trickster/templates/ingress.yaml
@@ -11,7 +11,8 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
 {{- range $key, $value := .Values.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}

--- a/charts/trickster/templates/pvc.yaml
+++ b/charts/trickster/templates/pvc.yaml
@@ -10,7 +10,8 @@ metadata:
 {{ toYaml .annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "trickster.labels" $ | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
   name: {{ .volName | printf "trickster-%s-claim" }}
 spec:
   accessModes:

--- a/charts/trickster/templates/service.yaml
+++ b/charts/trickster/templates/service.yaml
@@ -14,7 +14,8 @@ metadata:
 {{- end }}
   name: {{ template "trickster.fullname" . }}
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
@@ -52,5 +53,6 @@ spec:
       nodePort: {{ .Values.service.metricsNodePort }}
     {{- end }}
   selector:
-    {{- include "trickster.matchLabels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 6 }}
   type: "{{ .Values.service.type }}"

--- a/charts/trickster/templates/service.yaml
+++ b/charts/trickster/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
 {{- if or .Values.service.annotations .Values.prometheusScrape }}
   annotations:
   {{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ toYaml .Values.service.annotations | nindent 4 }}
   {{- end }}
   {{- if .Values.prometheusScrape }}
     prometheus.io/scrape: {{ .Values.prometheusScrape | quote }}
@@ -54,5 +54,5 @@ spec:
     {{- end }}
   selector:
     app: {{ template "trickster.name" . }}
-    {{- include "trickster.labels" . | indent 6 }}
+    {{- include "trickster.labels" . | indent 4 }}
   type: "{{ .Values.service.type }}"

--- a/charts/trickster/templates/servicemonitor.yaml
+++ b/charts/trickster/templates/servicemonitor.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ template "trickster.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
+    app: {{ template "trickster.name" . }}
+    {{- include "trickster.labels" . | indent 4 }}
 {{- if .Values.prometheus.serviceMonitor.labels }}
 {{ toYaml .Values.prometheus.serviceMonitor.labels | indent 4 }}
 {{- end }}
@@ -13,7 +14,8 @@ spec:
   jobLabel: {{ template "trickster.name" . }}
   selector:
     matchLabels:
-    {{- include "trickster.labels" . | nindent 6 }}
+      app: {{ template "trickster.name" . }}
+      {{- include "trickster.labels" . | indent 6 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,6 +3,6 @@ remote: origin
 chart-dirs:
   - charts
 chart-repos:
-  - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
+  - incubator=https://charts.helm.sh/incubator
   - elastic=https://helm.elastic.co
 helm-extra-args: --timeout=500


### PR DESCRIPTION
Add Kubernetes recommanded labels https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Ex: 

```yaml
---
# Source: trickster/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app: trickster    
    app.kubernetes.io/component: trickster-infra
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: trickster
    app.kubernetes.io/part-of: trickster 
    app.kubernetes.io/version: "1.5.4"
    helm.sh/chart: trickster-1.5.4 
    tricksterproxy.io/version: "1.1"
  name: RELEASE-NAME-trickster
data:
  trickster.conf: |-
    [main]

    [frontend]
    listen_port = 8480
    connections_limit = 0

    [origins]

      [origins.default]
      origin_type = "prometheus"
      origin_url = "http://prometheus:9090"

    [metrics]
    listen_port = 8481
---
# Source: trickster/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-trickster
  labels:
    app: trickster    
    app.kubernetes.io/component: trickster-infra
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: trickster
    app.kubernetes.io/part-of: trickster 
    app.kubernetes.io/version: "1.5.4"
    helm.sh/chart: trickster-1.5.4 
    tricksterproxy.io/version: "1.1"
  name: RELEASE-NAME-trickster
spec:
  ports:
    - name: http
      port: 8480
      protocol: TCP
      targetPort: http
    - name: http-metrics
      port: 8481
      protocol: TCP
      targetPort: metrics
  selector:
    app: trickster    
    app.kubernetes.io/component: trickster-infra
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: trickster
    app.kubernetes.io/part-of: trickster 
    app.kubernetes.io/version: "1.5.4"
    helm.sh/chart: trickster-1.5.4 
    tricksterproxy.io/version: "1.1"
  type: "ClusterIP"
---
# Source: trickster/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: trickster    
    app.kubernetes.io/component: trickster-infra
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: trickster
    app.kubernetes.io/part-of: trickster 
    app.kubernetes.io/version: "1.5.4"
    helm.sh/chart: trickster-1.5.4 
    tricksterproxy.io/version: "1.1"
  name: RELEASE-NAME-trickster
spec:
  selector:
    matchLabels:
      app: trickster      
      app.kubernetes.io/name: trickster
      app.kubernetes.io/instance: RELEASE-NAME
  replicas: 1
  template:
    metadata:
      annotations:
        checksum/trickster-cfg: dd0e638923c8f32c6fb65904e0e41455a48c4dee1d1a00d95acc156aa3b16f63    
      labels:
        app: trickster        
        app.kubernetes.io/component: trickster-infra
        app.kubernetes.io/instance: RELEASE-NAME
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: trickster
        app.kubernetes.io/part-of: trickster 
        app.kubernetes.io/version: "1.5.4"
        helm.sh/chart: trickster-1.5.4 
        tricksterproxy.io/version: "1.1"
    spec:    
      containers:
        - name: trickster
          image: "tricksterproxy/trickster:1.1"
          imagePullPolicy: IfNotPresent
          volumeMounts:
            - name: cfg-volume
              mountPath: /etc/trickster
          ports:
            - name: http
              containerPort: 8480
              protocol: TCP
            - name: metrics
              containerPort: 8481
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /trickster/ping
              port: http
          readinessProbe:
            httpGet:
              path: /trickster/ping
              port: http
          resources:
            {}
      volumes:
        - name: cfg-volume
          configMap:
            name: RELEASE-NAME-trickster
            items:
              - key: trickster.conf
                path: trickster.conf
        - name: cache-volume-generic
          emptyDir: {}

```